### PR TITLE
Fix for pc_login_get() missing 1 required positional argument: 'apicompute'

### DIFF
--- a/pc_lib_general.py
+++ b/pc_lib_general.py
@@ -116,7 +116,7 @@ def pc_settings_write(username, password, uiBase, apiCompute="",
 
 
 # Work out login information
-def pc_login_get(username, password, uibase, apicompute):
+def pc_login_get(username, password, uibase, apicompute=""):
     pc_settings = {}
     if username is None and password is None and uibase is None:
         pc_settings = pc_settings_read()


### PR DESCRIPTION
…ame, args.password, args.uiurl)

TypeError: pc_login_get() missing 1 required positional argument: 'apicompute'